### PR TITLE
Found a couple things while running through acceptance tests

### DIFF
--- a/src/RabbitMqNext/Amqp/BasicProperties.cs
+++ b/src/RabbitMqNext/Amqp/BasicProperties.cs
@@ -61,9 +61,9 @@ namespace RabbitMqNext
 			// _headers = headers ?? new Dictionary<string, object>(StringComparer.Ordinal);
 
 			if (isFrozen)
-				_headers = new ReadOnlyDictionary<string, object>(EmptyDict);
+				_headers = headers ?? new ReadOnlyDictionary<string, object>(EmptyDict);
 			else
-				_headers = new Dictionary<string, object>(StringComparer.Ordinal);
+				_headers = headers ?? new Dictionary<string, object>(StringComparer.Ordinal);
 		}
 
 		public bool IsContentTypePresent
@@ -335,7 +335,7 @@ namespace RabbitMqNext
 				_type = this._type,
 				_userId = this._userId,
 				_appId = this._appId,
-				_clusterId = this._clusterId,
+				_clusterId = this._clusterId
 			};
 			
 			return cloned;

--- a/src/RabbitMqNext/Amqp/BasicProperties.cs
+++ b/src/RabbitMqNext/Amqp/BasicProperties.cs
@@ -61,9 +61,9 @@ namespace RabbitMqNext
 			// _headers = headers ?? new Dictionary<string, object>(StringComparer.Ordinal);
 
 			if (isFrozen)
-				_headers = headers ?? new ReadOnlyDictionary<string, object>(EmptyDict);
+				_headers = new ReadOnlyDictionary<string, object>(headers ?? EmptyDict);
 			else
-				_headers = headers ?? new Dictionary<string, object>(StringComparer.Ordinal);
+				_headers = new Dictionary<string, object>(headers ?? EmptyDict, StringComparer.Ordinal);
 		}
 
 		public bool IsContentTypePresent
@@ -301,7 +301,6 @@ namespace RabbitMqNext
 		{
 			get
 			{
-				ThrowIfFrozen();
 				return _headers;
 			}
 //			private set

--- a/src/RabbitMqNext/Internals/AmqpPrimitivesReader.cs
+++ b/src/RabbitMqNext/Internals/AmqpPrimitivesReader.cs
@@ -1,14 +1,14 @@
 namespace RabbitMqNext.Internals
 {
-	using System;
-	using System.Buffers;
-	using System.Collections;
-	using System.Collections.Generic;
-	using System.Text;
-	using RingBuffer;
+    using System;
+    using System.Buffers;
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Text;
+    using RingBuffer;
+    using System.Linq;
 
-
-	internal class AmqpPrimitivesReader
+    internal class AmqpPrimitivesReader
 	{
 		private readonly ArrayPool<byte> _bufferPool = ArrayPool<byte>.Create(131072, 20); // typical max frame = 131072 
 		private readonly byte[] _smallBuffer = new byte[300];
@@ -35,26 +35,23 @@ namespace RabbitMqNext.Internals
 
 		public IDictionary<string, object> ReadTable()
 		{
-			// unbounded allocation! bad
-			var table = new Dictionary<string, object>(capacity: 11);
+            return ReadKeyValues().ToDictionary(kv => kv.Key, kv => kv.Value);
+        }
 
-			ReadTable(table);
-
-			return table;
-		}
-
-		public void ReadTable(IDictionary<string, object> table)
+		public IEnumerable<KeyValuePair<String, object>> ReadKeyValues()
 		{
 			uint tableLength = _reader.ReadUInt32();
-			if (tableLength == 0) return;
+			if (tableLength == 0) return new KeyValuePair<String, object>[] { };
 
+            var kvs = new List<KeyValuePair<String, object>>();
 			var marker = new RingBufferPositionMarker(_reader._ringBufferStream);
 			while (marker.LengthRead < tableLength)
 			{
 				string key = ReadShortStr();
 				object value = ReadFieldValue();
-				table[key] = value;
+                kvs.Add(new KeyValuePair<string, object>(key, value));
 			}
+            return kvs;
 		}
 
 		public string ReadShortStr()

--- a/src/RabbitMqNext/Internals/MessagesPendingConfirmationKeeper.cs
+++ b/src/RabbitMqNext/Internals/MessagesPendingConfirmationKeeper.cs
@@ -56,15 +56,15 @@ namespace RabbitMqNext.Internals
 				tcs.TrySetException(new Exception("ConfirmationKeeper: Could not find free spot for the waiting task"));
 			}
 
-			if (LogAdapter.IsWarningEnabled)
-				LogAdapter.LogWarn(LogSource, string.Format("Confirm: took " + index));
+			if (LogAdapter.IsDebugEnabled)
+				LogAdapter.LogDebug(LogSource, string.Format("Confirm: took " + index));
 		}
 		
 		// invoked from the read frame thread only. continuations need to be executed async
 		public void Confirm(ulong deliveryTag, bool multiple, bool requeue, bool isAck)
 		{
-			if (LogAdapter.IsWarningEnabled)
-				LogAdapter.LogWarn(LogSource, string.Format("Confirming delivery {0} lastConfirmed {4}  M: {1} Reque: {2} isAck: {3}", deliveryTag, multiple, requeue, isAck, _lastConfirmed));
+			if (LogAdapter.IsDebugEnabled)
+				LogAdapter.LogDebug(LogSource, string.Format("Confirming delivery {0} lastConfirmed {4}  M: {1} Reque: {2} isAck: {3}", deliveryTag, multiple, requeue, isAck, _lastConfirmed));
 
 			var startPos = multiple ? _lastConfirmed + 1 : deliveryTag;
 

--- a/src/RabbitMqNext/Internals/Protocol/FrameReader_ChannelLevel.cs
+++ b/src/RabbitMqNext/Internals/Protocol/FrameReader_ChannelLevel.cs
@@ -120,7 +120,7 @@ namespace RabbitMqNext.Internals
 				properties._presenceSWord = presence;
 				if (properties.IsContentTypePresent) { properties.ContentType =  _amqpReader.ReadShortStr(); }
 				if (properties.IsContentEncodingPresent) { properties.ContentEncoding =  _amqpReader.ReadShortStr(); }
-				if (properties.IsHeadersPresent) { _amqpReader.ReadTable(properties.Headers); }
+				if (properties.IsHeadersPresent) { properties.Headers=_amqpReader.ReadTable(); }
 				if (properties.IsDeliveryModePresent) { properties.DeliveryMode = _amqpReader.ReadOctet(); }
 				if (properties.IsPriorityPresent) { properties.Priority = _amqpReader.ReadOctet(); }
 				if (properties.IsCorrelationIdPresent) { properties.CorrelationId =  _amqpReader.ReadShortStr(); }

--- a/src/RabbitMqNext/Internals/Protocol/FrameReader_ChannelLevel.cs
+++ b/src/RabbitMqNext/Internals/Protocol/FrameReader_ChannelLevel.cs
@@ -120,7 +120,7 @@ namespace RabbitMqNext.Internals
 				properties._presenceSWord = presence;
 				if (properties.IsContentTypePresent) { properties.ContentType =  _amqpReader.ReadShortStr(); }
 				if (properties.IsContentEncodingPresent) { properties.ContentEncoding =  _amqpReader.ReadShortStr(); }
-				if (properties.IsHeadersPresent) { properties.Headers=_amqpReader.ReadTable(); }
+				if (properties.IsHeadersPresent) { _amqpReader.ReadTable(properties.Headers); }
 				if (properties.IsDeliveryModePresent) { properties.DeliveryMode = _amqpReader.ReadOctet(); }
 				if (properties.IsPriorityPresent) { properties.Priority = _amqpReader.ReadOctet(); }
 				if (properties.IsCorrelationIdPresent) { properties.CorrelationId =  _amqpReader.ReadShortStr(); }

--- a/src/RabbitMqNext/Internals/Protocol/FrameReader_ChannelLevel.cs
+++ b/src/RabbitMqNext/Internals/Protocol/FrameReader_ChannelLevel.cs
@@ -237,7 +237,7 @@ namespace RabbitMqNext.Internals
 			bool multiple = _amqpReader.ReadBits() != 0;
 
 			if (LogAdapter.ProtocolLevelLogEnabled)
-				LogAdapter.LogError(LogSource, "< BasicAck : " + deliveryTags + " multiple " + multiple);
+				LogAdapter.LogDebug(LogSource, "< BasicAck : " + deliveryTags + " multiple " + multiple);
 
 			channel.ProcessAcks(deliveryTags, multiple);
 		}
@@ -250,7 +250,7 @@ namespace RabbitMqNext.Internals
 			bool requeue = (bits & 2) != 0;
 
 			if (LogAdapter.ProtocolLevelLogEnabled)
-				LogAdapter.LogError(LogSource, "< BasicNAck from server for  " + deliveryTags + " multiple:  " + multiple + " requeue " + requeue);
+				LogAdapter.LogDebug(LogSource, "< BasicNAck from server for  " + deliveryTags + " multiple:  " + multiple + " requeue " + requeue);
 
 			channel.ProcessNAcks(deliveryTags, multiple, requeue);
 		}
@@ -279,7 +279,7 @@ namespace RabbitMqNext.Internals
 			uint messageCount = _amqpReader.ReadLong();
 
 			if (LogAdapter.ProtocolLevelLogEnabled)
-				LogAdapter.LogError(LogSource, "< GenericMessageCount : " + messageCount);
+				LogAdapter.LogDebug(LogSource, "< GenericMessageCount : " + messageCount);
 
 			return continuation(messageCount);
 		}
@@ -290,7 +290,7 @@ namespace RabbitMqNext.Internals
 			var noWait = _amqpReader.ReadBits();
 
 			if (LogAdapter.ProtocolLevelLogEnabled)
-				LogAdapter.LogError(LogSource, "< BasicCancel : " + consumerTag + " bits " + noWait);
+				LogAdapter.LogDebug(LogSource, "< BasicCancel : " + consumerTag + " bits " + noWait);
 
 			return continuation(consumerTag, noWait);
 		}

--- a/src/RabbitMqNext/Internals/RingBuffer/ByteRingBuffer.cs
+++ b/src/RabbitMqNext/Internals/RingBuffer/ByteRingBuffer.cs
@@ -110,8 +110,8 @@
 
 				if (_state._resetApplied)
 				{
-					throw new Exception("Can't be Written since the buffer is in Reset state"); 
-					// break;
+					//throw new Exception("Can't be Written since the buffer is in Reset state"); 
+					break;
 				}
 
 				if (available == 0)
@@ -157,7 +157,7 @@
 				if (_state._resetApplied)
 				{
 					throw new Exception("Can't be read since the buffer is in Reset state");
-					// break;
+					//break;
 				}
 
 				if (available == 0)
@@ -196,8 +196,8 @@
 
 				if (_state._resetApplied)
 				{
-					throw new Exception("Can't be read since the buffer is in Reset state");
-					// break;
+					//throw new Exception("Can't be read since the buffer is in Reset state");
+				    break;
 				}
 
 				if (available == 0)
@@ -291,8 +291,8 @@
 
 				if (_state._resetApplied)
 				{
-					throw new Exception("Can't be Skipped since the buffer is in Reset state"); 
-					// break;
+					//throw new Exception("Can't be Skipped since the buffer is in Reset state"); 
+					break;
 				}
 
 				// var available = (int)this.InternalGetReadyToReadEntries(offset - totalSkipped);
@@ -348,7 +348,7 @@
 				{
 					FireClosed(ex);
 
-					throw;
+					//throw;
 				}
 			}
 			else

--- a/src/RabbitMqNext/Internals/RingBuffer/ByteRingBuffer.cs
+++ b/src/RabbitMqNext/Internals/RingBuffer/ByteRingBuffer.cs
@@ -110,8 +110,8 @@
 
 				if (_state._resetApplied)
 				{
-					//throw new Exception("Can't be Written since the buffer is in Reset state"); 
-					break;
+					throw new Exception("Can't be Written since the buffer is in Reset state"); 
+					//break;
 				}
 
 				if (available == 0)
@@ -196,15 +196,15 @@
 
 				if (_state._resetApplied)
 				{
-					//throw new Exception("Can't be read since the buffer is in Reset state");
-				    break;
+					throw new Exception("Can't be read since the buffer is in Reset state");
+				    //break;
 				}
 
 				if (available == 0)
 				{
 					if (fillBuffer)
 					{
-						FillUpBufferFromSocket();
+					    FillUpBufferFromSocket();
 						// _writeLock.WaitOne();
 						continue;
 					} 
@@ -291,15 +291,15 @@
 
 				if (_state._resetApplied)
 				{
-					//throw new Exception("Can't be Skipped since the buffer is in Reset state"); 
-					break;
+					throw new Exception("Can't be Skipped since the buffer is in Reset state"); 
+					//break;
 				}
 
 				// var available = (int)this.InternalGetReadyToReadEntries(offset - totalSkipped);
 				if (available == 0)
 				{
 					// _writeLock.Wait();
-					FillUpBufferFromSocket();
+				    FillUpBufferFromSocket();
 					continue;
 				}
 
@@ -347,8 +347,7 @@
 				catch (Exception ex)
 				{
 					FireClosed(ex);
-
-					//throw;
+				    throw;
 				}
 			}
 			else

--- a/src/RabbitMqNext/MessageDelivery.cs
+++ b/src/RabbitMqNext/MessageDelivery.cs
@@ -55,15 +55,13 @@ namespace RabbitMqNext
 
 		private static Stream CloneStream(Stream originalStream, int bodySize)
 		{
-			if (originalStream == null) return null; 
-			
-			var original = originalStream as MemoryStream; // Empty Stream then
-			if (original != null)
-			{
-				return original;
-			}
+			if (originalStream == null) return null;
 
-			var original2 = originalStream as MemoryStream2; // Empty Stream then
+            // Empty Stream then
+            if (originalStream is EmptyStream || originalStream is MemoryStream)
+                return originalStream;
+
+			var original2 = originalStream as MemoryStream2; 
 			if (original2 != null)
 			{
 				return new MemoryStream2(original2.InnerBuffer);


### PR DESCRIPTION
Headers weren't being copied when MessageDelivery.SafeCopy was used and it was not detecting EmptyStream

A couple of log messages that should have been Debug were Warn or Error

More major is I changed the reader and writer threads to not throw exceptions, changed all but 1 back to break because for me at least when I closed the sockets the threads always printed exceptions about not being able to read/write because of _resetApplied  
Maybe I'm the only one who notices because the NSB transport im working on starts multiple connections and kills them occasionally.  

After some looking, the only exception that actually gets handled is in FillUpBufferFromSocket which uses it to close the socket - imo its a lot cleaner debug-wise like this and I checked the log history the change from break to throw was to do something with recovery but I didnt see where those exceptions were handled in that case either.  And even when recovery on the threads still die --- so I dunno, something to look into.
